### PR TITLE
verified solution of real linear solver

### DIFF
--- a/src/IntervalLinearAlgebra.jl
+++ b/src/IntervalLinearAlgebra.jl
@@ -3,6 +3,7 @@ module IntervalLinearAlgebra
 using StaticArrays, Requires, Reexport
 
 import CommonSolve: solve
+import IntervalArithmetic: mid
 
 function  __init__()
     @require IntervalConstraintProgramming = "138f1668-1576-5ad7-91b9-7425abbf3153" include("solvers/oettli.jl")
@@ -14,7 +15,7 @@ end
 export
     LinearKrawczyk, Jacobi, GaussSeidel, GaussianElimination, HansenBliekRohn, NonLinearOettliPrager, LinearOettliPrager,
     NoPrecondition, InverseMidpoint, InverseDiagonalMidpoint,
-    solve, enclose,
+    solve, enclose, epsilon_inflation,
     comparison_matrix, interval_norm, interval_isapprox, list_orthants,
     is_H_matrix, is_strongly_regular, is_strictly_diagonally_dominant, is_Z_matrix, is_M_matrix,
     rref
@@ -23,6 +24,7 @@ export
 include("solvers/hull.jl")
 include("solvers/precondition.jl")
 include("solvers/solve.jl")
+include("solvers/verify.jl")
 
 include("utils.jl")
 include("classify.jl")

--- a/src/solvers/verify.jl
+++ b/src/solvers/verify.jl
@@ -1,0 +1,97 @@
+##
+# routines to give a rigorous solution of the real linear system Ax=B
+
+"""
+    epsilon_inflation(A::AbstractMatrix{T}, b::AbstractArray{S, N};
+                      r=0.1, ϵ=1e-20, iter_max=20) where {T<:Real, S<:Real, N}
+
+    epsilon_inflation(A::AbstractMatrix{T}, b::AbstractArray{S, N};
+                      r=0.1, ϵ=1e-20, iter_max=20) where {T<:Interval, S<:Interval, N}
+
+Gives an enclosure of the solution of the square linear system ``Ax=b``
+using the ϵ-inflation algorithm,  see algorithm 10.7 of [[RUM10]](@ref)
+
+### Input
+
+* `A`        -- square matrix of size n × n
+* `b`        -- vector of length n or matrix of size n × m
+* `r`        -- relative inflation, default 10%
+* `ϵ`        -- absolute inflation, default 1e-20
+* `iter_max` -- maximum number of iterations
+
+### Output
+
+* `x`    -- enclosure of the solution of the linear system
+* `cert` -- Boolean flag, if `cert==true`, then `x` is *certified* to contain the true
+solution of the linear system, if `cert==false`, then the algorithm could not prove that ``x``
+actually contains the true solution.
+
+### Algorithm
+
+Given the real system ``Ax=b`` and an approximate solution ``̃x``, we initialize
+``x₀ = [̃x, ̃x]``. At each iteration the algorithm computes the inflation
+
+``y = xₖ * [1 - r, 1 + r] .+ [-ϵ, ϵ]``
+
+and the update
+
+``xₖ₊₁ = Z + (I - CA)y``,
+
+where ``Z = C(b - Ax₀)`` and ``C`` is an approximate inverse of ``A``. If the condition
+``xₖ₊₁ ⊂ y `` is met, then ``xₖ₊₁`` is a proved enclosure of ``A⁻¹b`` and `cert` is set to
+true. If the condition is not met by the maximum number of iterations, the
+latest computed enclosure is returned, but ``cert`` is set to false, meaning the algorithm
+could not prove that the enclosure contains the true solution. For interval systems,
+``̃x`` is obtained considering the midpoint of ``A`` and ``b``.
+
+### Notes
+
+- This algorithm is meant for *real* linear systems, or interval systems with
+very tiny intervals. For interval linear systems with wider intervals, see the
+[`solve`](@ref) function.
+
+### Examples
+
+```jldoctest
+julia> A = [1 2;3 4]
+2×2 Matrix{Int64}:
+ 1  2
+ 3  4
+
+julia> b = A * ones(2)
+2-element Vector{Float64}:
+ 3.0
+ 7.0
+
+julia> x, cert = epsilon_inflation(A, b)
+(Interval{Float64}[[0.999999, 1.00001], [0.999999, 1.00001]], true)
+
+julia> ones(2) .∈ x
+2-element BitVector:
+ 1
+ 1
+
+julia> cert
+true
+```
+"""
+function epsilon_inflation(A::AbstractMatrix{T}, b::AbstractArray{S, N};
+                           r=0.1, ϵ=1e-20, iter_max=20) where {T<:Real, S<:Real, N}
+
+    r1 = Interval(1 - r, 1 + r)
+    ϵ1 = Interval(-ϵ, ϵ)
+    R = inv(mid.(A))
+    C = I - R * A
+    xs = R * mid.(b)
+    z = R * (b - (A * Interval.(xs)))
+    x = z
+
+    for _ in 1:iter_max
+        y = r1 * x .+ ϵ1
+        x = z + C * y
+        if all(x .⊂ y)
+            return xs + x, true
+        end
+    end
+    return xs + x, false
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,5 @@
+mid(x::Real) = x
+
 """
     interval_isapprox(a::Interval, b::Interval; kwargs)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using IntervalLinearAlgebra, StaticArrays, IntervalConstraintProgramming, LazySets
 using Test
 
+const IA = IntervalArithmetic
+
 @testset "IntervalLinearAlgebra.jl" begin
 
     @testset "Utils" begin
@@ -136,8 +138,8 @@ using Test
         @test all(ones(n) .∈ x)
         @test cert
 
-        Ain = convert.(Interval{Float64}, Interval.(Arat, Arat))
-        bin = convert.(Interval{Float64}, Interval.(brat, brat))
+        Ain = convert.(IA.Interval{Float64}, IA.Interval.(Arat, Arat))
+        bin = convert.(IA.Interval{Float64}, IA.Interval.(brat, brat))
 
         x, cert = epsilon_inflation(Ain, bin)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,4 +122,43 @@ using Test
         A2 = fill(0..0, 2, 2)
         @test_throws ArgumentError rref(A2)
     end
+
+    @testset "Verified linear solver" begin
+
+        n = 4
+        Arat = reshape(1 .//(1:n^2), n, n)
+        brat = Arat*fill(1//1, n)
+        Afloat = float(Arat)
+        bfloat = float(brat)
+
+        x, cert = epsilon_inflation(Afloat, bfloat)
+
+        @test all(ones(n) .∈ x)
+        @test cert
+
+        Ain = convert.(Interval{Float64}, Interval.(Arat, Arat))
+        bin = convert.(Interval{Float64}, Interval.(brat, brat))
+
+        x, cert = epsilon_inflation(Ain, bin)
+
+        @test all(ones(n) .∈ x)
+        @test cert
+
+        # big float test
+        Abig = BigFloat.(Arat)
+        bbig = BigFloat.(brat)
+
+        x, cert = epsilon_inflation(Abig, bbig)
+
+        @test cert
+        @test all(diam.(x) .< 1e-50)
+        @test all(ones(n) .∈ x)
+
+        # case when should not be possible to certify
+        A = [1..2 1..4;0..1 0..1]
+        b = A*[1; 1]
+
+        _, cert = epsilon_inflation(A, b)
+        @test !cert
+    end
 end


### PR DESCRIPTION
## Description

Add functionality to give a rigorous bound of the real square linear system Ax=b. The algorithm is based on Theorem 10.6 and its improvement described [here](https://www.tuhh.de/ti3/paper/rump/Ru10.pdf)

## Related issues

fixes #21 

## To-do

- [x] add tests
- [x] think of a better name the current one `verified_linear_solver` is not necessarily good. **edit**: chose epsilon_inflation