### PR TITLE
implemented different precondition mechanisms

### DIFF
--- a/src/IntervalLinearAlgebra.jl
+++ b/src/IntervalLinearAlgebra.jl
@@ -9,7 +9,7 @@ end
 
 export
     Krawczyk, Jacobi, GaussSeidel, GaussElimination, HansenBliekRohn,
-    Precondition, NoPrecondition, InverseMidpointPrecondition, InverseDiagonalMidpointPrecondition,
+    Precondition, NoPrecondition, InverseMidpoint, InverseDiagonalMidpoint,
     solve, enclose, precondition, oettli,
     comparison_matrix, interval_norm, interval_isapprox,
     is_H_matrix, is_strongly_regular, is_strictly_diagonally_dominant, is_Z_matrix, is_M_matrix

--- a/src/IntervalLinearAlgebra.jl
+++ b/src/IntervalLinearAlgebra.jl
@@ -9,12 +9,14 @@ end
 
 export
     Krawczyk, Jacobi, GaussSeidel, GaussElimination, HansenBliekRohn,
+    Precondition, NoPrecondition, InverseMidpointPrecondition, InverseDiagonalMidpointPrecondition,
     solve, enclose, precondition, oettli,
     comparison_matrix, interval_norm, interval_isapprox,
     is_H_matrix, is_strongly_regular, is_strictly_diagonally_dominant, is_Z_matrix, is_M_matrix
 
 
 include("solvers/solvers.jl")
+include("solvers/precondition.jl")
 include("utils.jl")
 include("classify.jl")
 end

--- a/src/solvers/precondition.jl
+++ b/src/solvers/precondition.jl
@@ -16,37 +16,37 @@ struct NoPrecondition <: Precondition end
 (np::NoPrecondition)(A, b) = A, b
 
 """
-    InverseMidpointPrecondition <: Precondition
+    InverseMidpoint <: Precondition
 
 Preconditioner that preconditions the linear system ``Ax=b`` with ``inv(Ac)``, where `Ac` is the midpoint matrix of ``A``.
 
 ### Example
 ```julia
-imp = InverseMidpointPrecondition() # instantiate preconditioner
+imp = InverseMidpoint() # instantiate preconditioner
 Aprec, bprec = imp(A, b) # apply preconditioner
 ```
 """
-struct InverseMidpointPrecondition <: Precondition end
+struct InverseMidpoint <: Precondition end
 
-function (icp::InverseMidpointPrecondition)(A, b)
+function (icp::InverseMidpoint)(A, b)
     R = inv(mid.(A))
     return R*A, R*b
 end
 
 """
-    InverseDiagonalMidpointPrecondition <: Precondition
+    InverseDiagonalMidpoint <: Precondition
 
 Preconditioner that preconditions the linear system ``Ax=b`` with ``inv(Diagonal(Ac))``, where `Ac` is the midpoint matrix of ``A``.
 
 ### Example
 ```julia
-idmp = InverseDiagonalMidpointPrecondition() # instantiate preconditioner
+idmp = InverseDiagonalMidpoint() # instantiate preconditioner
 Aprec, bprec = idmp(A, b) # apply preconditioner
 ```
 """
-struct InverseDiagonalMidpointPrecondition <: Precondition end
+struct InverseDiagonalMidpoint <: Precondition end
 
-function (idp::InverseDiagonalMidpointPrecondition)(A, b)
+function (idp::InverseDiagonalMidpoint)(A, b)
     R = inv(Diagonal(mid.(A)))
     return R*A, R*b
 end

--- a/src/solvers/precondition.jl
+++ b/src/solvers/precondition.jl
@@ -1,0 +1,52 @@
+abstract type Precondition end
+
+"""
+    NoPrecondition <: Precondition
+
+Trivial preconditioner which does nothing.
+
+### Example
+```julia
+np = NoPrecondition() # instantiate preconditioner
+Aprec, bprec = np(A, b) # apply preconditioner
+```
+"""
+struct NoPrecondition <: Precondition end
+
+(np::NoPrecondition)(A, b) = A, b
+
+"""
+    InverseMidpointPrecondition <: Precondition
+
+Preconditioner that preconditions the linear system ``Ax=b`` with ``inv(Ac)``, where `Ac` is the midpoint matrix of ``A``.
+
+### Example
+```julia
+imp = InverseMidpointPrecondition() # instantiate preconditioner
+Aprec, bprec = imp(A, b) # apply preconditioner
+```
+"""
+struct InverseMidpointPrecondition <: Precondition end
+
+function (icp::InverseMidpointPrecondition)(A, b)
+    R = inv(mid.(A))
+    return R*A, R*b
+end
+
+"""
+    InverseDiagonalMidpointPrecondition <: Precondition
+
+Preconditioner that preconditions the linear system ``Ax=b`` with ``inv(Diagonal(Ac))``, where `Ac` is the midpoint matrix of ``A``.
+
+### Example
+```julia
+idmp = InverseDiagonalMidpointPrecondition() # instantiate preconditioner
+Aprec, bprec = idmp(A, b) # apply preconditioner
+```
+"""
+struct InverseDiagonalMidpointPrecondition <: Precondition end
+
+function (idp::InverseDiagonalMidpointPrecondition)(A, b)
+    R = inv(Diagonal(mid.(A)))
+    return R*A, R*b
+end

--- a/src/solvers/solvers.jl
+++ b/src/solvers/solvers.jl
@@ -158,7 +158,7 @@ end
 Base.show(io::IO, s::LinearSolver) = print(io, string(s))
 ## wrapper
 
-function solve(A, b, method, precondition=InverseMidpointPrecondition())
+function solve(A, b, method, precondition=InverseMidpoint())
 
     A, b = precondition(A, b)
     x = enclose(A, b)
@@ -168,7 +168,7 @@ function solve(A, b, method, precondition=InverseMidpointPrecondition())
     return x
 end
 
-function solve(A, b, method::HansenBliekRohn, precondition=InverseMidpointPrecondition())
+function solve(A, b, method::HansenBliekRohn, precondition=InverseMidpoint())
     A, b = precondition(A, b)
     return method(A, b)
 end

--- a/src/solvers/solvers.jl
+++ b/src/solvers/solvers.jl
@@ -158,7 +158,7 @@ end
 Base.show(io::IO, s::LinearSolver) = print(io, string(s))
 ## wrapper
 
-function solve(A, b, method)
+function solve(A, b, method, precondition=InverseMidpointPrecondition())
 
     A, b = precondition(A, b)
     x = enclose(A, b)
@@ -168,7 +168,7 @@ function solve(A, b, method)
     return x
 end
 
-function solve(A, b, method::HansenBliekRohn)
+function solve(A, b, method::HansenBliekRohn, precondition=InverseMidpointPrecondition())
     A, b = precondition(A, b)
     return method(A, b)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,16 +10,6 @@ interval_norm(v::AbstractVector) = maximum(mag.(v))
 # ? use manual loops instead
 
 """
-Preconditions the interval system Ax = b by multipling by the (approximate) inverse of Ac,
-that is the midpoint of A.
-"""
-function precondition(A, b)
-    Ac_inv = inv(mid.(A))
-    return Ac_inv*A, Ac_inv*b
-end
-
-
-"""
     enclose(A::Matrix{Interval}, b::Vector{Interval})
 
 Computes an initial enclosure Σ so that x ⊆ Σ, where x is the solution of the interval

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,8 +7,8 @@ using Test
         b = [-2..2, -2..2]
 
         np = NoPrecondition()
-        idp = InverseDiagonalMidpointPrecondition()
-        imp = InverseMidpointPrecondition()
+        idp = InverseDiagonalMidpoint()
+        imp = InverseMidpoint()
 
         A1, b1 = np(A, b)
         @test A1 == A && b1 == b

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,28 @@ using IntervalLinearAlgebra, StaticArrays, IntervalArithmetic, IntervalConstrain
 using Test
 
 @testset "IntervalLinearAlgebra.jl" begin
-    
+    @testset "precondition" begin
+        A = [2..4 -2..1; -1..2 2..4]
+        b = [-2..2, -2..2]
+
+        np = NoPrecondition()
+        idp = InverseDiagonalMidpointPrecondition()
+        imp = InverseMidpointPrecondition()
+
+        A1, b1 = np(A, b)
+        @test A1 == A && b1 == b
+
+        A2, b2 = idp(A, b)
+        Acorrect = [2/3..4/3 -2/3..1/3; -1/3..2/3 2/3..4/3]
+        bcorrect = [-2/3..2/3, -2/3..2/3]
+        @test all(interval_isapprox.(A2, Acorrect)) && all(interval_isapprox.(b2, bcorrect))
+
+        A3, b3 = imp(A, b)
+        Acorrect = [22/37..52/37 -20/37..20/37;-20/37..20/37 22/37..52/37]
+        bcorrect = [-28/37..28/37, -28/37..28/37]
+        @test all(interval_isapprox.(A3, Acorrect)) && all(interval_isapprox.(b3, bcorrect))
+    end
+
     @testset "Test linear solvers" begin
         As = @SMatrix [4..6 -1..1 -1..1 -1..1;-1..1 -6.. -4 -1..1 -1..1;-1..1 -1..1 9..11 -1..1;-1..1 -1..1 -1..1 -11.. -9]
         bs = @SVector [-2..4, 1..8, -4..10, 2..12]


### PR DESCRIPTION
## Description

implements three different precondition mechanisms (no precondition, inverse midpont, inverse diagonal midpoint) and allows user to choose what precondition to use. 

## Related issues
fixes #12 

## Questions

Are the names too verbose? Maybe it could just be `InverseMidpoint`, `InverseDiagonalMidpoint`, `NoPrecondition`. It should be clear that the first two are preconditioners from the type signature.
