### PR TITLE
restructure solve interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Luca Ferranti"]
 version = "0.1.0"
 
 [deps]
+CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -11,6 +12,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
+CommonSolve = "0.2"
 IntervalArithmetic = "0.18"
 IntervalConstraintProgramming = "0.12"
 Reexport = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -13,11 +13,11 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 CommonSolve = "0.2"
-IntervalArithmetic = "0.18"
-IntervalConstraintProgramming = "0.12"
+IntervalArithmetic = "0.17, 0.18"
+IntervalConstraintProgramming = "0.9, 0.10, 0.11, 0.12"
 Reexport = "1"
 Requires = "1"
-StaticArrays = "0.12, 1"
+StaticArrays = "1"
 julia = "1.6"
 
 [extras]

--- a/src/IntervalLinearAlgebra.jl
+++ b/src/IntervalLinearAlgebra.jl
@@ -1,7 +1,8 @@
 module IntervalLinearAlgebra
 
-# Write your package code here.
 using StaticArrays, Requires, Reexport
+
+import CommonSolve: solve
 
 function  __init__()
     @require IntervalConstraintProgramming = "138f1668-1576-5ad7-91b9-7425abbf3153" include("solvers/oettli.jl")

--- a/src/IntervalLinearAlgebra.jl
+++ b/src/IntervalLinearAlgebra.jl
@@ -19,8 +19,10 @@ export
     rref
 
 
-include("solvers/solvers.jl")
+include("solvers/hull.jl")
 include("solvers/precondition.jl")
+include("solvers/solve.jl")
+
 include("utils.jl")
 include("classify.jl")
 include("rref.jl")

--- a/src/solvers/hull.jl
+++ b/src/solvers/hull.jl
@@ -8,7 +8,7 @@ abstract type IterativeSolver <: LinearSolver end
     HansenBliekRohn()
 
 Returns a Hansen-Bliek-Rohn solver for the interval linear system Ax=b.
-""" 
+"""
 struct HansenBliekRohn <: DirectSolver end
 
 function (hbr::HansenBliekRohn)(A, b)
@@ -35,7 +35,7 @@ struct GaussElimination <: DirectSolver end
 function (ge::GaussElimination)(A, b)
     n = length(b)
     Abrref = rref([A b])
-    
+
     # backsubstitution
     x = similar(b)
     x[end] = Abrref[n, n+1]/Abrref[n, n]
@@ -58,7 +58,7 @@ max_iterations: maximum number of iterations (default 20)
 
 atol: absolute tolerance (default 0), if at some point `|xₖ - xₖ₊₁| < atol` (elementwise), then stop and return xₖ₊₁.
     If atol=0, then `min(diam(A))*1e-5` is used.
-""" 
+"""
 struct Jacobi <: IterativeSolver
     max_iterations::Int
     atol::Float64
@@ -97,7 +97,7 @@ max_iterations: maximum number of iterations (default 20)
 
 atol: absolute tolerance (default 0), if at some point `|xₖ - xₖ₊₁| < atol` (elementwise), then stop and return xₖ₊₁.
     If atol=0, then `min(diam(A))*1e-5` is used.
-""" 
+"""
 struct GaussSeidel <: IterativeSolver
     max_iterations::Int
     atol::Float64
@@ -135,7 +135,7 @@ max_iterations: maximum number of iterations (default 20)
 
 atol: absolute tolerance (default 0), if at some point `|xₖ - xₖ₊₁| < atol` (elementwise), then stop and return xₖ₊₁.
     If atol=0, then `min(diam(A))*1e-5` is used.
-""" 
+"""
 struct Krawczyk <: IterativeSolver
     max_iterations::Int
     atol::Float64
@@ -171,19 +171,3 @@ function Base.string(s::LinearSolver)
 end
 
 Base.show(io::IO, s::LinearSolver) = print(io, string(s))
-## wrapper
-
-function solve(A, b, method::IterativeSolver, precondition=InverseMidpoint())
-
-    A, b = precondition(A, b)
-    x = enclose(A, b)
-
-    method(x, A, b)
-
-    return x
-end
-
-function solve(A, b, method::DirectSolver, precondition=InverseMidpoint())
-    A, b = precondition(A, b)
-    return method(A, b)
-end

--- a/src/solvers/solve.jl
+++ b/src/solvers/solve.jl
@@ -1,0 +1,51 @@
+function solve(A, b,
+               solver::IterativeSolver,
+               precondition::Precondition=_default_precondition(A, solver))
+
+    A, b = precondition(A, b)
+    x = enclose(A, b)
+
+    solver(x, A, b)
+
+    return x
+end
+
+function solve(A, b,
+               solver::DirectSolver,
+               precondition::Precondition=_default_precondition(A, solver))
+
+    A, b = precondition(A, b)
+    return solver(A, b)
+end
+
+
+# fallback
+function solve(A, b,
+               solver::LinearSolver=_default_solver(),
+               precondition::Precondition=_default_precondition(A, solver))
+
+    A, b = precondition(A, b)
+    return solver(A, b)
+end
+
+## Default settings
+_default_solver() = GaussElimination()
+
+function _default_precondition(A, ::GaussElimination)
+    if is_strictly_diagonally_dominant(A) || is_M_matrix(A)
+        return NoPrecondition()
+    else
+        return InverseMidpoint()
+    end
+end
+
+function _default_precondition(A, ::HansenBliekRohn)
+    if is_H_matrix(A)
+        return NoPrecondition()
+    else
+        return InverseMidpoint()
+    end
+end
+
+# fallback
+_default_precondition(_, ::LinearSolver) = InverseMidpoint()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,7 +35,7 @@ using Test
         hbr = HansenBliekRohn()
         kra = Krawczyk()
 
-        for (A, b) in zip([As, Am], [bs, bm])        
+        for (A, b) in zip([As, Am], [bs, bm])
             xgs = solve(A, b, gs)
             xjac = solve(A, b, jac)
             xhbr = solve(A, b, hbr)
@@ -52,10 +52,13 @@ using Test
         ge = GaussElimination()
         xge = solve(Am, bm, ge)
         @test all(interval_isapprox.(xge, [-2.6..3.1, -3.9..1.5, -1.43..2.15, -2.35..0.6]; atol=0.01))
+
+        xdef = solve(Am, bm)
+        @test all(interval_isapprox.(xdef, [-2.6..3.1, -3.9..1.5, -1.43..2.15, -2.35..0.6]; atol=0.01))
     end
-    
+
     @testset "oettli-präger method" begin
-        
+
         A = [2..4 -2..1; -1..2 2..4]
         b = [-2..2, -2..2]
         vars = (:x, :y)
@@ -102,4 +105,3 @@ using Test
         @test_throws ArgumentError rref(A2)
     end
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,14 @@ using Test
 
         xdef = solve(Am, bm)
         @test all(interval_isapprox.(xdef, [-2.6..3.1, -3.9..1.5, -1.43..2.15, -2.35..0.6]; atol=0.01))
+
+        A = [2..4 -2..1; -1..2 2..4]
+        b = [-2..2, -2..2]
+
+        x1 = solve(A, b)
+        @test all(interval_isapprox.(x1, [-14..14, -14..14]))
+        x2 = solve(A, b, HansenBliekRohn())
+        @test all(interval_isapprox.(x2, [-14..14, -14..14]))
     end
 
     @testset "oettli-präger method" begin


### PR DESCRIPTION
- If preconditioning is not specified is automatically chosen depending on the type of matrix and problem
- extend interface from `CommonSolve.jl`